### PR TITLE
Expose package and service ensure params

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED
 - Add `package_ensure` param.
+- Add `service_ensure` param.
 
 2014-12-05 Release 0.0.1
 - Initial release.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+UNRELEASED
+- Add `package_ensure` param.
+
 2014-12-05 Release 0.0.1
 - Initial release.
 - Manage package/config/service.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-UNRELEASED
+2014-12-08 Release 0.1.0
 - Add `package_ensure` param.
 - Add `service_ensure` param.
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'alphagov-heka'
-version       '0.0.1'
+version       '0.1.0'
 source        'https://github.com/alphagov/puppet-heka'
 author        'Government Digital Service'
 license       'MIT'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,8 +8,13 @@
 #   Ensure parameter to pass to the package.
 #   Default: present
 #
+# [*service_ensure*]
+#   Ensure parameter to pass to the service.
+#   Default: running
+#
 class heka (
   $package_ensure = present,
+  $service_ensure = running,
 ) {
   anchor { 'heka::begin': } ->
   class { 'heka::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,13 @@
 #
 # === Parameters
 #
-class heka {
+# [*package_ensure*]
+#   Ensure parameter to pass to the package.
+#   Default: present
+#
+class heka (
+  $package_ensure = present,
+) {
   anchor { 'heka::begin': } ->
   class { 'heka::install': } ->
   class { 'heka::config': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,9 @@
 # == Class heka::install
 #
 class heka::install {
+  $package_ensure = $::heka::package_ensure
+
   package { 'heka':
-    ensure => present,
+    ensure => $package_ensure,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,12 +1,18 @@
 # == Class heka::service
 #
 # This class is meant to be called from heka
-# It ensure the service is running
 #
 class heka::service {
+  $service_ensure = $::heka::service_ensure
+  $service_enable = $service_ensure ? {
+    stopped => false,
+    false   => false,
+    default => true,
+  }
+
   service { 'heka':
-    ensure     => running,
-    enable     => true,
+    ensure     => $service_ensure,
+    enable     => $service_enable,
     hasstatus  => true,
     hasrestart => true,
   }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,5 +1,17 @@
 require 'spec_helper'
 
-describe 'heka::install' do
-  it { should contain_package('heka') }
+describe 'heka' do
+  context 'package_ensure present (default)' do
+    let(:params) {{ }}
+
+    it { should contain_package('heka').with_ensure('present') }
+  end
+
+  context 'package_ensure 1.2.3' do
+    let(:params) {{
+      :package_ensure => '1.2.3',
+    }}
+
+    it { should contain_package('heka').with_ensure('1.2.3') }
+  end
 end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,5 +1,40 @@
 require 'spec_helper'
 
-describe 'heka::service' do
-  it { should contain_service('heka') }
+describe 'heka' do
+  context 'service_ensure running (default)' do
+    let(:params) {{ }}
+
+    it {
+      should contain_service('heka').with({
+        :ensure => 'running',
+        :enable => true,
+      })
+    }
+  end
+
+  context 'service_ensure stopped' do
+    let(:params) {{
+      :service_ensure => 'stopped',
+    }}
+
+    it {
+      should contain_service('heka').with({
+        :ensure => 'stopped',
+        :enable => false,
+      })
+    }
+  end
+
+  context 'service_ensure false' do
+    let(:params) {{
+      :service_ensure => false,
+    }}
+
+    it {
+      should contain_service('heka').with({
+        :ensure => false,
+        :enable => false,
+      })
+    }
+  end
 end


### PR DESCRIPTION
#### Add package_ensure param

So that consumers of this module can specify a specific package version or
"latest". Modified the test to call the outer class where our public params
are, as we've done for other modules like puppet-gor.
#### Add service_ensure param

So that consumers of this module can stop the service if they wish. Modified
the test to call the outer class where our public params are, as we've done
for other modules like puppet-gor.
#### Release 0.1.0
