### PR TITLE
Add {encoder,output}_options to ES plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+UNRELEASED
+- Add `encoder_options` and `output_options` params to
+  `heka::plugin::elasticsearch`.
+
 2014-12-12 Release 0.2.0
 - Add `protocol` param to `heka::plugin::graphite`.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-UNRELEASED
+2014-12-16 Release 0.3.0
 - Add `encoder_options` and `output_options` params to
   `heka::plugin::elasticsearch`.
 

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'alphagov-heka'
-version       '0.2.0'
+version       '0.3.0'
 source        'https://github.com/alphagov/puppet-heka'
 author        'Government Digital Service'
 license       'MIT'

--- a/manifests/plugin/elasticsearch.pp
+++ b/manifests/plugin/elasticsearch.pp
@@ -11,11 +11,22 @@
 #   Whether to use Logstash V0 format.
 #   Default: false
 #
+# [*encoder_options*]
+#   Hash of arbitrary options for the encoder.
+#   Default: {}
+#
+# [*output_options*]
+#   Hash of arbitrary options for the output.
+#   Default: {}
+#
 class heka::plugin::elasticsearch (
   $url,
   $logstash_v0 = false,
+  $encoder_options = {},
+  $output_options = {},
 ) {
   validate_bool($logstash_v0)
+  validate_hash($encoder_options, $output_options)
 
   $encoder = $logstash_v0 ? {
     false => 'ESJsonEncoder',

--- a/spec/classes/plugin_elasticsearch_spec.rb
+++ b/spec/classes/plugin_elasticsearch_spec.rb
@@ -39,4 +39,66 @@ describe 'heka::plugin::elasticsearch' do
       })}
     end
   end
+
+  describe 'encoder_options' do
+    context '{} (default)' do
+      let(:params) {{
+        :url => 'http://elasticsearch.example.com:9200',
+      }}
+
+      it { should contain_heka__plugin('elasticsearch').with({
+        :content => /^es_index_from_timestamp =.+$\Z/,
+      })}
+    end
+
+    context 'populated with different types' do
+      let(:params) {{
+        :url              => 'http://elasticsearch.example.com:9200',
+        :encoder_options  => {
+          'int_quoted'    => '100',
+          'int_unquoted'  => 200,
+          'bool_quoted'   => 'true',
+          'bool_unquoted' => false,
+          'string'        => 'thing',
+        },
+      }}
+
+      it { should contain_heka__plugin('elasticsearch').with_content(/^int_quoted = 100$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^int_unquoted = 200$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^bool_quoted = true$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^bool_unquoted = false$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^string = "thing"$/) }
+    end
+  end
+
+  describe 'output_options' do
+    context '{} (default)' do
+      let(:params) {{
+        :url => 'http://elasticsearch.example.com:9200',
+      }}
+
+      it { should contain_heka__plugin('elasticsearch').with({
+        :content => /^es_index_from_timestamp =.+$\Z/,
+      })}
+    end
+
+    context 'populated with different types' do
+      let(:params) {{
+        :url              => 'http://elasticsearch.example.com:9200',
+        :output_options  => {
+          'int_quoted'    => '100',
+          'int_unquoted'  => 200,
+          'bool_quoted'   => 'true',
+          'bool_unquoted' => false,
+          'string'        => 'thing',
+        },
+      }}
+
+      it { should contain_heka__plugin('elasticsearch').with_content(/^int_quoted = 100$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^int_unquoted = 200$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^bool_quoted = true$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^bool_unquoted = false$/) }
+      it { should contain_heka__plugin('elasticsearch').with_content(/^string = "thing"$/) }
+    end
+  end
 end

--- a/templates/etc/heka/elasticsearch.toml.erb
+++ b/templates/etc/heka/elasticsearch.toml.erb
@@ -2,8 +2,26 @@
 server = "<%= @url -%>"
 encoder = "<%= @encoder -%>"
 message_matcher = "Logger != 'hekad' && Type != 'heka.statmetric'"
+<% @output_options.each do |k,v| -%>
+<%= k -%> = <%=
+if [true, false, "true", "false"].include?(v)
+  v
+else
+  Integer(v) rescue "\"#{v}\""
+end
+%>
+<% end -%>
 
 [<%= @encoder -%>]
 type_name = "%{Type}"
 index = "logs-%{2006.01.02}"
 es_index_from_timestamp = true
+<% @encoder_options.each do |k,v| -%>
+<%= k -%> = <%=
+if [true, false, "true", "false"].include?(v)
+  v
+else
+  Integer(v) rescue "\"#{v}\""
+end
+%>
+<% end -%>


### PR DESCRIPTION
I'd like to set the `flush_interval` option for `ElasticSearchOutput`.

However I don't want to keep modifying these plugins every time I need to
use a new option. So I'm exposing the ability to set arbitrary options using
a hash. Some futzing is required to ensure that the TOML file contains
entries of the right type.

If this is successful then I anticipate doing the same for the other
plugins. We'd probably want to keep separate `host` and `port` params,
because they are always used and some have sensible defaults like binding to
loopback. But everything else could become a hash - possibly even existing
hardcoded options.
