### PR TITLE
Add comments referring to puppet in every file installed

### DIFF
--- a/files/etc/init/heka.conf
+++ b/files/etc/init/heka.conf
@@ -1,3 +1,5 @@
+# This file is controlled via puppet. Any changes you make in here
+# will be clobbered when puppet is next run.
 description "Heka"
 
 start on runlevel [2345]

--- a/files/usr/share/heka/lua_decoders/json_event.lua
+++ b/files/usr/share/heka/lua_decoders/json_event.lua
@@ -1,3 +1,5 @@
+-- This file is controlled via puppet. Any changes you make in here
+-- will be clobbered when puppet is next run.
 --[[
 Parse logstash json_event entries.
 

--- a/templates/etc/heka/dashboard.toml.erb
+++ b/templates/etc/heka/dashboard.toml.erb
@@ -1,3 +1,5 @@
+# This file is controlled via puppet. Any changes you make in here
+# will be clobbered when puppet is next run.
 [DashboardOutput]
 address = "<%= @host -%>:<%= @port -%>"
 ticker_interval = <%= @interval %>

--- a/templates/etc/heka/graphite.toml.erb
+++ b/templates/etc/heka/graphite.toml.erb
@@ -1,3 +1,5 @@
+# This file is controlled via puppet. Any changes you make in here
+# will be clobbered when puppet is next run.
 [CarbonOutput]
 address = "<%= @host -%>:<%= @port -%>"
 <% if @protocol -%>

--- a/templates/etc/heka/tcp_input.toml.erb
+++ b/templates/etc/heka/tcp_input.toml.erb
@@ -1,3 +1,5 @@
+# This file is controlled via puppet. Any changes you make in here
+# will be clobbered when puppet is next run.
 [HekaRemoteInput]
 type = "TcpInput"
 decoder = "ProtobufDecoder"

--- a/templates/etc/heka/tcp_output.toml.erb
+++ b/templates/etc/heka/tcp_output.toml.erb
@@ -1,3 +1,5 @@
+# This file is controlled via puppet. Any changes you make in here
+# will be clobbered when puppet is next run.
 [HekaRemoteOutput]
 type = "TcpOutput"
 address = "<%= @host -%>:<%= @port -%>"


### PR DESCRIPTION
In order to distinguish files on the system managed by puppet from those
provided by the system or a package (which may or may not be edited on
the system and then persist), we should document that a particular file
is installed by Puppet.

This applies the comment #5 to the other files managed by this module
