### PR TITLE
Raise ulimit

### DIFF
--- a/files/etc/init/heka.conf
+++ b/files/etc/init/heka.conf
@@ -8,4 +8,6 @@ stop on runlevel [!2345]
 respawn
 respawn limit 5 120
 
+limit nofile 4096 4096
+
 exec hekad -config /etc/heka

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,6 +14,6 @@ class heka::service {
     ensure     => $service_ensure,
     enable     => $service_enable,
     hasstatus  => true,
-    hasrestart => true,
+    hasrestart => false,
   }
 }


### PR DESCRIPTION
#### Raise nofile ulimit for Heka daemon

I've observed some of our Heka instances producing errors because they're
run out of file descriptors. This seems quite plausible given enough log
files and TCP connections. So raise the limit from 1024 to 4096.
#### Disable service hasrestart

To force upstart to pick up changes to our init script, such as the `limit`
stanza in the previous commit. Without this a `reload` will be issued and
Heka won't pick up the limits.
