### PR TITLE
Upstart restart redux

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,10 +8,12 @@ class heka::config {
     recurse => true,
     purge   => true,
     force   => true,
+    notify  => Class['heka::service'],
   }
 
   file { '/etc/init/heka.conf':
     ensure => file,
     source => 'puppet:///modules/heka/etc/init/heka.conf',
+    notify => Class['heka::restart'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,8 @@ class heka (
   $package_ensure = present,
   $service_ensure = running,
 ) {
+  include heka::restart
+
   anchor { 'heka::begin': } ->
   class { 'heka::install': } ->
   class { 'heka::config': }
@@ -24,5 +26,5 @@ class heka (
 
   Anchor['heka::begin']  ~> Class['heka::service']
   Class['heka::install'] ~> Class['heka::service']
-  Class['heka::config']  ~> Class['heka::service']
+  Class['heka::config']  -> Class['heka::service']
 }

--- a/manifests/restart.pp
+++ b/manifests/restart.pp
@@ -1,0 +1,9 @@
+# == Class: heka::restart
+#
+# Restart (not HUP) the Heka service.
+#
+class heka::restart {
+  exec { '/usr/sbin/service heka restart':
+    refreshonly => true,
+  }
+}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,6 +14,6 @@ class heka::service {
     ensure     => $service_ensure,
     enable     => $service_enable,
     hasstatus  => true,
-    hasrestart => false,
+    hasrestart => true,
   }
 }


### PR DESCRIPTION
#### Revert "Disable service hasrestart"

This reverts commit b82b09a.

I don't think this is quite the right solution to the problem because we'll
never make use of HUP for Heka's own config changes (even if Heka doesn't
currently support it correctly - it may in the future).
#### Hard restart on upstart config changes

So that upstart picks up changes like the recently added `limit` stanza. But
we do the "normal" thing of reloading and sending a HUP signal for changes
to Heka's own configs.
