### PR TITLE
Add matcher_additional param to tcp_output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2015-01-19 Release 0.5.0
+- Add `matcher_additional` param to `heka::plugin::tcp_output`.
+
 2015-01-14 Release 0.4.0
 - Raise file descriptor limit for Heka daemon.
 - Restart (rather than reload) on upstart config changes.

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name          'alphagov-heka'
-version       '0.4.0'
+version       '0.5.0'
 source        'https://github.com/alphagov/puppet-heka'
 author        'Government Digital Service'
 license       'MIT'

--- a/manifests/plugin/tcp_output.pp
+++ b/manifests/plugin/tcp_output.pp
@@ -15,10 +15,16 @@
 #   machine that also has `heka::plugin::tcp_input`.
 #   Default: false
 #
+# [*matcher_additional*]
+#   Additional `message_matcher` expressions to filter messages that you
+#   don't want to send to another host.
+#   Default: ''
+#
 class heka::plugin::tcp_output (
   $host,
   $port,
   $enable = true,
+  $matcher_additional = '',
 ) {
   validate_bool($enable)
 

--- a/spec/classes/plugin_tcp_output_spec.rb
+++ b/spec/classes/plugin_tcp_output_spec.rb
@@ -32,4 +32,29 @@ describe 'heka::plugin::tcp_output' do
       it { should have_heka__plugin_resource_count(0) }
     end
   end
+
+  describe 'matcher_additional' do
+    context '"" (default)' do
+      let(:params) {{
+        :host => 'heka.example.com',
+        :port => 9999,
+      }}
+
+      it { should contain_heka__plugin('tcp_output').with({
+        :content => /^message_matcher = "Logger != 'hekad' && Type != 'heka.statmetric'"$/,
+      })}
+    end
+
+    context '"Fields[http_host] != \'sekret.example.com\'"' do
+      let(:params) {{
+        :host               => 'heka.example.com',
+        :port               => 9999,
+        :matcher_additional => 'Fields[http_host] != \'sekret.example.com\'',
+      }}
+
+      it { should contain_heka__plugin('tcp_output').with({
+        :content => /^message_matcher = "Logger != 'hekad' && Type != 'heka.statmetric' && Fields\[http_host\] != 'sekret\.example\.com'"$/,
+      })}
+    end
+  end
 end

--- a/templates/etc/heka/tcp_output.toml.erb
+++ b/templates/etc/heka/tcp_output.toml.erb
@@ -3,4 +3,4 @@
 [HekaRemoteOutput]
 type = "TcpOutput"
 address = "<%= @host -%>:<%= @port -%>"
-message_matcher = "Logger != 'hekad' && Type != 'heka.statmetric'"
+message_matcher = "Logger != 'hekad' && Type != 'heka.statmetric'<%= " && #{@matcher_additional}" unless @matcher_additional.empty? -%>"


### PR DESCRIPTION
I intend to use this to filter out access logs from signon per:
gds/puppet@ac441dd783e1e64e5f078718783ef95c09021055

The only alternative I could see to this was adding some logic to our JSON
decoder. But that would mean either rendering it from a template or passing
LUA code through to be evaled, both of which don't seem right.
